### PR TITLE
bugfix in action predicate removal

### DIFF
--- a/generate-asp-model.py
+++ b/generate-asp-model.py
@@ -57,6 +57,8 @@ if __name__ == '__main__':
                  instance_file, '--only-output-direct-program']
     if args.inequality_rules:
         command.extend(['--inequality-rules'])
+    if args.no_duplicate_arguments:
+        command.extend(['--no-duplicate-arguments'])
     execute(command, stdout=theory_output_with_actions)
     print("ASP model *with actions* being copied to %s" % theory_output_with_actions)
 

--- a/src/translate/options.py
+++ b/src/translate/options.py
@@ -62,6 +62,11 @@ def parse_args():
         dest="inequality_rules", action="store_true",
         help="add inequalities to rules")
     argparser.add_argument(
+        "--no-duplicate-arguments",
+        dest="no_duplicate_arguments", action="store_true",
+        help="enforce that all arguments (ie., variables) in rule heads have different "
+             "names by adding new variables and equality conditions.")
+    argparser.add_argument(
         "--only-output-htd-program",
         dest="only_output_htd_program", action="store_true",
         help="only output program after hypertree decomposition (no grounding)")

--- a/src/translate/pddl_to_prolog.py
+++ b/src/translate/pddl_to_prolog.py
@@ -133,19 +133,16 @@ class PrologProgram:
 
         final_rules = []
         for r in non_action_rules:
-            if len(r.conditions) == 1:
-                condition_name = str(r.conditions[0])
-                if condition_name in action_rules.keys():
-                    new_action_rule = copy.deepcopy(action_rules[condition_name])
-                    new_action_rule.effect = r.effect
-                    # TODO If we use lifted costs, this should be done before
-                    new_action_rule.weight = 1
-                    final_rules.append(new_action_rule)
-                else:
-                    # TODO If we use lifted costs, this should be done before
-                    r.weight = 0
-                    final_rules.append(r)
+            condition_name = str(r.conditions[0])
+            if condition_name in action_rules.keys():
+                new_action_rule = copy.deepcopy(action_rules[condition_name])
+                new_action_rule.conditions += r.conditions[1:]
+                new_action_rule.effect = r.effect
+                # TODO If we use lifted costs, this should be done before
+                new_action_rule.weight = 1
+                final_rules.append(new_action_rule)
             else:
+                r.weight = 0
                 final_rules.append(r)
         self.rules = final_rules
 

--- a/src/translate/pddl_to_prolog.py
+++ b/src/translate/pddl_to_prolog.py
@@ -40,7 +40,8 @@ class PrologProgram:
         # 2. The variables that appear in each effect or condition are distinct.
         # 3. There are no rules with empty condition.
         self.remove_free_effect_variables()
-        self.split_duplicate_arguments()
+        if options.no_duplicate_arguments:
+            self.split_duplicate_arguments()
         self.convert_trivial_rules()
     def split_rules(self):
         import split_rules

--- a/utils.py
+++ b/utils.py
@@ -40,6 +40,9 @@ def parse_arguments():
     parser.add_argument('--fd-split', action='store_true', help="Use Fast Downward rule splitting.")
     parser.add_argument('--htd-split', action='store_true', help="Use HTD rule splitting.")
     parser.add_argument("--inequality-rules", dest="inequality_rules", action="store_true", help="add inequalities to rules")
+    parser.add_argument("--no-duplicate-arguments", dest="no_duplicate_arguments", action="store_true",
+                        help="enforce that all arguments (i.e., variables) in rule heads have different names by adding "
+                        "new variables and equality conditions.")
 
     args = parser.parse_args()
     if args.domain is None:


### PR DESCRIPTION
Hi,
this is my proposed fix for [the action predicate removal issue](https://github.com/abcorrea/asp-grounding-planning/issues/2).

I am not entirely sure it is correct. In particular I am concerned about the following two things:
* My implementation assumes, that if the action_predicate atom occurs in a body, it is always listed first. This seems reasonable to me, but I am not 100% certain I can assume that.
* In your previous implementation you did not change the weight of the rule if the condition size is `!= 1`, this is different now. If this was important, then this needs to be adjusted in my implementation. 